### PR TITLE
Update Build.yml

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         path: BabbleApp
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: BabbleApp
         path: BabbleApp/dist/windows


### PR DESCRIPTION
V2 was deprecated and would now always fail, update to V4 to continue functioning.