### PR TITLE
(feat/fix) Add Linux installer script, fix misc_utils.py, update README

### DIFF
--- a/BabbleApp/utils/misc_utils.py
+++ b/BabbleApp/utils/misc_utils.py
@@ -6,12 +6,16 @@ import os
 import platform
 import cv2
 import subprocess
-from pygrabber.dshow_graph import FilterGraph
 
-is_nt = True if sys.platform.startswith('win') else False
-graph = FilterGraph()
+# Detect the operating system
+is_nt = os.name == "nt"
+os_type = platform.system()
 
-
+if is_nt:
+    from pygrabber.dshow_graph import FilterGraph
+    graph = FilterGraph()
+    
+    
 def list_camera_names():
     cam_list = graph.get_input_devices()
     cam_names = []
@@ -19,14 +23,6 @@ def list_camera_names():
         cam_names.append(name)
     cam_names = cam_names + list_serial_ports()
     return cam_names
-
-# Detect the operating system
-is_nt = True if os.name == "nt" else False
-os_type = platform.system()
-
-if is_nt:
-    from pygrabber.dshow_graph import FilterGraph
-    graph = FilterGraph()
 
 
 def list_cameras_opencv():

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 ![Babble Logo](https://github.com/SummerSigh/ProjectBabble/blob/SummerSigh-patch-4/Babble.png?raw=true)
 
 <h3 align="center">
@@ -32,8 +31,15 @@ Once it's finished installing, you can update and run the Babble app by typing `
 
 *You should also be able to run the Windows executable through Wine!*
 
-#### Note:
-If you recieve a `ModuleNotFoundError: No module named 'tkinter'` error message on run, you'll need to install `tkinter` for your distro.
+#### Notes:
+If you receive a `["Error listing UVC devices on Linux ... No such file or directory"]` when choosing/changing your camera, you'll need to install video4linux (`v4l-utils`) for your distro.
+
+For Ubuntu or other distros with apt:
+```bash
+sudo apt-get install v4l-utils
+```
+
+If you receive a `ModuleNotFoundError: No module named 'tkinter'` error message on run, you'll need to install `tkinter` for your distro.
 
 For Ubuntu or other distros with apt:
 ```bash

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Project Babble is an open-source mouth tracking project designed to work with an
 - [Links](#links)
   
 ## Features
-- 100% Opensource! 🌟
+- 100% open-source! 🌟
 - Fast and robust! 🚀
-- Works with most existing blendshape standards! ⚙️
+- Works with existing blendshape standards! ⚙️
 - Constantly updated and modified! 🔧
 
 ## Installation
@@ -24,25 +24,32 @@ Head to the releases section and [download the latest installer](https://github.
 ### Linux
 Copy, paste and run the following script into the terminal of your choice:
 
-```bash -c "$(curl -fsSL https://gist.githubusercontent.com/dfgHiatus/a92a3caae24c1bfab1c7544537a654c5/raw/494a4bc5ed6c97745c7a283661d2f5530ba3d949/project-babble-install.sh)"```
+```bash
+bash -c "$(curl -fsSL https://gist.githubusercontent.com/dfgHiatus/a92a3caae24c1bfab1c7544537a654c5/raw/494a4bc5ed6c97745c7a283661d2f5530ba3d949/project-babble-install.sh)"
+```
 
 Once it's finished installing, you can update and run the Babble app by typing `babble-app` into your terminal.
 
 *You should also be able to run the Windows executable through Wine!*
 
 #### Note:
-If you recieve a `ModuleNotFoundError: No module named 'tkinter'` error message on run, you'll need to install `tkinter` for your distro:
-- For Ubuntu or other distros with apt:
-```sudo apt-get install python3-tk```
-- For Fedora:
-```sudo dnf install python3-tkinter```
+If you recieve a `ModuleNotFoundError: No module named 'tkinter'` error message on run, you'll need to install `tkinter` for your distro.
+
+For Ubuntu or other distros with apt:
+```bash
+sudo apt-get install python3-tk
+```
+For Fedora:
+```bash
+sudo dnf install python3-tkinter
+```
 
 You can read more about this [here](https://stackoverflow.com/questions/25905540/importerror-no-module-named-tkinter).
 
 ## Usage 
-We have integrations for [VRChat](https://docs.babble.diy/docs/software/integrations/vrc), [Resonite](https://docs.babble.diy/docs/software/integrations/resonite) or [ChilloutVR](https://docs.babble.diy/docs/software/integrations/chilloutVR)!
+We have integrations for [VRChat](https://docs.babble.diy/docs/software/integrations/vrc), [Resonite](https://docs.babble.diy/docs/software/integrations/resonite) and [ChilloutVR](https://docs.babble.diy/docs/software/integrations/chilloutVR)!
 
-Looking for something else? Check out our [documentation](https://docs.babble.diy/) here!
+Looking for something else? Check out our [documentation](https://docs.babble.diy/)!
 
 ## Links
 - [Our Discord](https://discord.gg/XAMZmjBktk)

--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ Project Babble is an open-source mouth tracking project designed to work with an
 Head to the releases section and [download the latest installer](https://github.com/Project-Babble/ProjectBabble/releases/latest).
 
 ### Linux
-Copy, paste and run the following script into the terminal of your choice:
+Install `git`, `curl` and a version of `python` greater than `3.8` for your distro. 
+
+Then, copy paste and run the following script into the terminal of your choice:
 
 ```bash
-bash -c "$(curl -fsSL https://gist.githubusercontent.com/dfgHiatus/a92a3caae24c1bfab1c7544537a654c5/raw/494a4bc5ed6c97745c7a283661d2f5530ba3d949/project-babble-install.sh)"
+bash -c "$(curl -fsSL https://gist.githubusercontent.com/dfgHiatus/a92a3caae24c1bfab1c7544537a654c5/raw/928904dfacfc193233ba842d0d137ec5874beac7/project-babble-install.sh)"
 ```
 
 Once it's finished installing, you can update and run the Babble app by typing `babble-app` into your terminal.

--- a/README.md
+++ b/README.md
@@ -1,38 +1,50 @@
 
 ![Babble Logo](https://github.com/SummerSigh/ProjectBabble/blob/SummerSigh-patch-4/Babble.png?raw=true)
 
-# Table of Contents
-- [What is Babble?](#what-is-babble)
+<h3 align="center">
+Project Babble is an open-source mouth tracking project designed to work with any VR headset. We strive to make our models robust to different lighting, cameras, image qualities and facial structures!
+</h3>
+
+## Table of Contents
 - [Features](#features)
-- [How do I set it up?](#setup-more-detailed-wiki-and-setup-video-coming-soon)
-- [Useful Links](#useful-links)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Links](#links)
   
-
-## What is Babble?
-
-<p align="center">
-Babble is an opensource mouth tracking project designed to work with any existing VR headset. We strive to make our models robust to different lighting, cameras, image qualities, and facial structures!
-</p>
-
 ## Features
 - 100% Opensource! 🌟
 - Fast and robust! 🚀
 - Works with most existing blendshape standards! ⚙️
 - Constantly updated and modified! 🔧
 
-## Setup (More detailed wiki and setup video coming soon!) 
-To install babble is fairly simple! Head over to the releases tab and download the EXE located there. Run the EXE and install babble! After that, you can test with a USB WEBCAM by doing the following steps: 
+## Installation
+### Windows
+Head to the releases section and [download the latest installer](https://github.com/Project-Babble/ProjectBabble/releases/latest).
 
-- Run the babble app
-- Enter 0 into the camera address bar
-- Enter cropping mode where your camera feed should be
-- Crop your mouth out of the frame
-- Open VRCFT
-- Install the babble module
-- Test in VRC with a VRCFT-compatible avatar
+### Linux
+Copy, paste and run the following script into the terminal of your choice:
 
+```bash -c "$(curl -fsSL https://gist.githubusercontent.com/dfgHiatus/a92a3caae24c1bfab1c7544537a654c5/raw/494a4bc5ed6c97745c7a283661d2f5530ba3d949/project-babble-install.sh)"```
 
-## Useful links
-- [Our Discord!](https://discord.gg/XAMZmjBktk)
+Once it's finished installing, you can update and run the Babble app by typing `babble-app` into your terminal.
+
+*You should also be able to run the Windows executable through Wine!*
+
+#### Note:
+If you recieve a `ModuleNotFoundError: No module named 'tkinter'` error message on run, you'll need to install `tkinter` for your distro:
+- For Ubuntu or other distros with apt:
+```sudo apt-get install python3-tk```
+- For Fedora:
+```sudo dnf install python3-tkinter```
+
+You can read more about this [here](https://stackoverflow.com/questions/25905540/importerror-no-module-named-tkinter).
+
+## Usage 
+We have integrations for [VRChat](https://docs.babble.diy/docs/software/integrations/vrc), [Resonite](https://docs.babble.diy/docs/software/integrations/resonite) or [ChilloutVR](https://docs.babble.diy/docs/software/integrations/chilloutVR)!
+
+Looking for something else? Check out our [documentation](https://docs.babble.diy/) here!
+
+## Links
+- [Our Discord](https://discord.gg/XAMZmjBktk)
+- [Our Twitter](https://x.com/projectBabbleVR)
 - [Wandb Runs](https://wandb.ai/summerai/ProjectBabble)
-

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Install `git`, `curl` and a version of `python` greater than `3.8` for your dist
 Then, copy paste and run the following script into the terminal of your choice:
 
 ```bash
-bash -c "$(curl -fsSL https://gist.githubusercontent.com/dfgHiatus/a92a3caae24c1bfab1c7544537a654c5/raw/928904dfacfc193233ba842d0d137ec5874beac7/project-babble-install.sh)"
+bash -c "$(curl -fsSL https://gist.githubusercontent.com/dfgHiatus/a92a3caae24c1bfab1c7544537a654c5/raw/fc30aa550c3c7aa83c37a72168e75ef92388e39b/project-babble-install.sh)"
 ```
 
 Once it's finished installing, you can update and run the Babble app by typing `babble-app` into your terminal.

--- a/babbleapp.sh
+++ b/babbleapp.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Check if running on Linux
+if [[ "$OSTYPE" != "linux-gnu"* ]]; then    
+    echo "Error: This script is only compatible with Linux operating systems."    
+    exit 1
+fi
+
+# Check Python version
+if ! command -v python3 &> /dev/null; then    
+    echo "Error: Python is not installed. Please install Python 3.11 or higher."    
+    exit
+fi  
+    
+python_version_major=$(python3 -c 'import platform; print(platform.python_version_tuple()[0])')
+python_version_minor=$(python3 -c 'import platform; print(platform.python_version_tuple()[1])')
+if (( python_version_major < 3 || python_version_minor < 11 )); then    
+    echo "Error: Your Python version is too low! Please install 3.11 or higher."    
+    exit 1
+fi
+
+# Set installation directory
+install_dir="$HOME/.local/share/project-babble"
+
+# Function to install requirements
+install_requirements() {
+    # Create a temporary requirements file without the Windows-only package
+    grep -v "onnxruntime-directml" requirements.txt > linux_requirements.txt
+    pip install -r linux_requirements.txt --quiet
+    rm linux_requirements.txt
+}
+
+# Function to update the repository
+update_repo() {    
+    echo "Checking for updates..."    
+    git fetch    
+    if [ "$(git rev-parse HEAD)" != "$(git rev-parse @{u})" ]; then        
+        echo "Updates found. Pulling changes..."        
+        git pull        
+        echo "Updating dependencies..."        
+        source venv/bin/activate        
+        install_requirements       
+        deactivate        
+
+        # Add babbleapp.sh to PATH    
+        mkdir -p "$HOME/.local/bin"    
+        ln -s "$install_dir/babbleapp.sh" "$HOME/.local/bin/babble-app"    
+        chmod +x "$HOME/.local/bin/babble-app"
+
+        # Add ~/.local/bin to PATH if not already present    
+        if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then        
+            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"            
+            echo "Please restart your terminal or run 'source ~/.bashrc' to update your PATH."    
+        fi
+
+        echo "Project Babble has been updated successfully!"    
+    else        
+        echo "Project Babble is already up to date."    
+    fi
+}
+
+cd $install_dir
+update_repo
+source venv/bin/activate  
+cd BabbleApp
+echo "Verifying dependencies. This might take a second!"
+install_requirements
+echo "Starting Babble app..."
+python3 babbleapp.py

--- a/babbleapp.sh
+++ b/babbleapp.sh
@@ -63,9 +63,15 @@ update_repo() {
 
 
 cd $install_dir
-update_repo
-source venv/bin/activate  
 cd BabbleApp
+
+# Create venv if it does not exists
+if ! [ -d "venv" ]; then
+    python3 -m venv venv
+fi
+
+source venv/bin/activate  
+update_repo
 echo "Verifying dependencies. This might take a second!"
 install_requirements
 echo "Starting Babble app..."

--- a/babbleapp.sh
+++ b/babbleapp.sh
@@ -8,14 +8,14 @@ fi
 
 # Check Python version
 if ! command -v python3 &> /dev/null; then    
-    echo "Error: Python is not installed. Please install Python 3.11 or higher."    
+    echo "Error: Python is not installed. Please install Python 3.8 or higher."    
     exit
 fi  
     
 python_version_major=$(python3 -c 'import platform; print(platform.python_version_tuple()[0])')
 python_version_minor=$(python3 -c 'import platform; print(platform.python_version_tuple()[1])')
-if (( python_version_major < 3 || python_version_minor < 11 )); then    
-    echo "Error: Your Python version is too low! Please install 3.11 or higher."    
+if (( python_version_major < 3 || python_version_minor < 8 )); then    
+    echo "Error: Your Python version is too low! Please install 3.8 or higher."    
     exit 1
 fi
 


### PR DESCRIPTION
The following PR adds a Linux installer script for Project Babble. At a very high level:

1. This clones the Project Babble repo to the user's computer.
2. Creates a virtual environment and installs any dependencies.
3. Adds `babble-app` to PATH, so you can run the app from the terminal.

This will also keep the app up to date. Tested on Mint Linux 22, should work on any x86-64 system.