### PR TITLE
(tweak) Add GPU priority list

### DIFF
--- a/BabbleApp/landmark_processor.py
+++ b/BabbleApp/landmark_processor.py
@@ -11,7 +11,7 @@ import numpy as np
 import cv2
 from enum import Enum
 from one_euro_filter import OneEuroFilter
-from utils.misc_utils import PlaySound, SND_FILENAME, SND_ASYNC
+from utils.misc_utils import PlaySound, SND_FILENAME, SND_ASYNC, onnx_providers
 #import importlib
 #from osc import Tab
 from osc_calibrate_filter import *
@@ -96,9 +96,14 @@ class LandmarkProcessor:
         self.opts.add_session_config_entry("session.intra_op.allow_spinning", "0")  # ~3% savings worth ~6ms avg latency. Not noticeable at 60fps?
         self.opts.enable_mem_pattern = False
         if self.runtime in ("ONNX", "Default (ONNX)"):    # ONNX
-            if self.use_gpu: provider = 'DmlExecutionProvider'
-            else: provider = "CPUExecutionProvider"  # Build onnxruntime to get both DML and OpenVINO
-            self.sess = ort.InferenceSession(f'{self.model}onnx/model.onnx', self.opts, providers=[provider, ], provider_options=[{'device_id': self.gpu_index}]) # Load Babble CNN until PFLD has been converted
+            if self.use_gpu: 
+                provider = onnx_providers
+            else: 
+                provider = [onnx_providers[-1]]
+            self.sess = ort.InferenceSession(
+                f'{self.model}onnx/model.onnx', 
+                self.opts, 
+                providers=provider)
             self.input_name = self.sess.get_inputs()[0].name
             self.output_name = self.sess.get_outputs()[0].name
         try:

--- a/BabbleApp/requirements.txt
+++ b/BabbleApp/requirements.txt
@@ -1,5 +1,6 @@
 onnxruntime==1.19.2
 onnxruntime-directml==1.19.2
+onnxruntime-gpu==1.20.1
 opencv_python==4.10.0.84
 pillow==11.0.0
 pysimplegui==4.70.1

--- a/BabbleApp/requirements.txt
+++ b/BabbleApp/requirements.txt
@@ -1,6 +1,6 @@
 onnxruntime==1.19.2
-onnxruntime-directml==1.19.2
-onnxruntime-gpu==1.20.1
+onnxruntime-directml==1.19.2; platform_system == "Windows"
+onnxruntime-gpu==1.19.2; platform_system == "Linux"
 opencv_python==4.10.0.84
 pillow==11.0.0
 pysimplegui==4.70.1

--- a/BabbleApp/utils/misc_utils.py
+++ b/BabbleApp/utils/misc_utils.py
@@ -12,7 +12,7 @@ bg_color_highlight = "#424042"
 bg_color_clear = "#242224"
 
 onnx_providers = [
-    # "DmlExecutionProvider",      # DirectML for Windows-specific GPU computing
+    "DmlExecutionProvider",      # DirectML for Windows-specific GPU computing
     "CUDAExecutionProvider",     # General GPU provider for NVIDIA CUDA
     # "TensorrtExecutionProvider", # NVIDIA TensorRT for GPU inference
     # "MIGraphXExecutionProvider", # AMD MIGraphX for AMD GPUs

--- a/BabbleApp/utils/misc_utils.py
+++ b/BabbleApp/utils/misc_utils.py
@@ -11,6 +11,19 @@ import subprocess
 bg_color_highlight = "#424042"
 bg_color_clear = "#242224"
 
+onnx_providers = [
+    # "DmlExecutionProvider",      # DirectML for Windows-specific GPU computing
+    "CUDAExecutionProvider",     # General GPU provider for NVIDIA CUDA
+    # "TensorrtExecutionProvider", # NVIDIA TensorRT for GPU inference
+    # "MIGraphXExecutionProvider", # AMD MIGraphX for AMD GPUs
+    # "ROCMExecutionProvider",     # AMD ROCm for AMD GPUs
+    # "VitisAIExecutionProvider",  # AMD Vitas AI for AMD CPUs
+    # "OpenVINOExecutionProvider", # Intel OpenVINO for GPUs/CPUs
+    # "DnnlExecutionProvider",     # Intel DNNL for CPU
+    # "TvmExecutionProvider",      # TVM (CPU, GPU, or accelerator). Preview, may be buggy
+    "CPUExecutionProvider",      # Default CPU fallback
+]
+
 # Detect the operating system
 is_nt = os.name == "nt"
 os_type = platform.system()


### PR DESCRIPTION
The purpose of this PR is twofold:
1) To identify and create platform-specific dependencies:

```python
...
onnxruntime-directml==1.19.2; platform_system == "Windows"
onnxruntime-gpu==1.19.2; platform_system == "Linux"
...
```

2) To evaluate `onnxruntime-gpu` as an execution provider. The current ONNX execution provider, `onnxruntme-directml` is Windows exclusive, and personally does not work on my machine anyways.