### PR TITLE
Fix serial connection on Linux

### DIFF
--- a/BabbleApp/camera.py
+++ b/BabbleApp/camera.py
@@ -10,7 +10,7 @@ from lang_manager import LocaleStringManager as lang
 
 from colorama import Fore
 from config import BabbleConfig, BabbleSettingsConfig
-from utils.misc_utils import get_camera_index_by_name, list_camera_names
+from utils.misc_utils import get_camera_index_by_name, list_camera_names, is_nt
 from enum import Enum
 import sys
 
@@ -267,17 +267,19 @@ class Camera:
             rate = 115200 if sys.platform == "darwin" else 3000000  # Higher baud rate not working on macOS
             conn = serial.Serial(baudrate=rate, port=port, xonxoff=False, dsrdtr=False, rtscts=False)
             # Set explicit buffer size for serial.
-            conn.set_buffer_size(rx_size=BUFFER_SIZE, tx_size=BUFFER_SIZE)
+            if is_nt:
+                conn.set_buffer_size(rx_size=BUFFER_SIZE, tx_size=BUFFER_SIZE)
 
             print(
                 f'{Fore.CYAN}[{lang._instance.get_string("log.info")}] {lang._instance.get_string("info.ETVRConnected")} {port}{Fore.RESET}'
             )
             self.serial_connection = conn
             self.camera_status = CameraState.CONNECTED
-        except Exception:
+        except Exception as e:
             print(
                 f'{Fore.CYAN}[{lang._instance.get_string("log.info")}] {lang._instance.get_string("info.ETVRFailiure")} {port}{Fore.RESET}'
             )
+            print(e)
             self.camera_status = CameraState.DISCONNECTED
 
     def clamp_max_res(self, image: MatLike) -> MatLike:

--- a/BabbleApp/camera.py
+++ b/BabbleApp/camera.py
@@ -86,7 +86,8 @@ class Camera:
                 self.config.capture_source is not None
                 and self.config.capture_source != ""
             ):
-                if "COM" in str(self.config.capture_source):
+                ports = ("COM", "/dev/ttyACM")
+                if any(x in str(self.config.capture_source) for x in ports):
                     if (
                         self.serial_connection is None
                         or self.camera_status == CameraState.DISCONNECTED
@@ -150,7 +151,7 @@ class Camera:
             if should_push and not self.capture_event.wait(timeout=0.02):
                 continue
             if self.config.capture_source is not None:
-                ports = ("COM", "/dev/tty")
+                ports = ("COM", "/dev/ttyACM")
                 if any(x in str(self.config.capture_source) for x in ports):
                     self.get_serial_camera_picture(should_push)
                 else:

--- a/BabbleApp/camera_widget.py
+++ b/BabbleApp/camera_widget.py
@@ -319,8 +319,10 @@ class CameraWidget:
                 # if value not in self.camera_list:
                 #    self.config.capture_source = value
                 # if "COM" not in value:
-                ports = ("COM", "/dev/tty")
+                ports = ("COM", "/dev/ttyACM")
+                print(f"Value: {value}")
                 if any(x in str(value) for x in ports):
+                    print("SERIAL PORT")
                     self.config.capture_source = value
                 else:
                     cam = get_camera_index_by_name(value)   # Set capture_source to the UVC index. Otherwise treat value like an ipcam if we return none
@@ -344,7 +346,7 @@ class CameraWidget:
                         and ".mp4" not in value
                         and "udp" not in value
                         and "COM" not in value
-                        and "/dev/tty" not in value
+                        and "/dev/ttyACM" not in value
                         and value not in self.camera_list
                     ):  # If http is not in camera address, add it.
                         self.config.capture_source = (

--- a/BabbleApp/camera_widget.py
+++ b/BabbleApp/camera_widget.py
@@ -320,9 +320,7 @@ class CameraWidget:
                 #    self.config.capture_source = value
                 # if "COM" not in value:
                 ports = ("COM", "/dev/ttyACM")
-                print(f"Value: {value}")
                 if any(x in str(value) for x in ports):
-                    print("SERIAL PORT")
                     self.config.capture_source = value
                 else:
                     cam = get_camera_index_by_name(value)   # Set capture_source to the UVC index. Otherwise treat value like an ipcam if we return none


### PR DESCRIPTION
Fixed linux serial port naming scheme not being parsed as a serial port. 
Only call setbuffer on Windows as the method doesn't exist on Linux. 