### PR TITLE
Fix requirements.txt and camera.py for Linux

### DIFF
--- a/BabbleApp/camera.py
+++ b/BabbleApp/camera.py
@@ -13,7 +13,7 @@ from lang_manager import LocaleStringManager as lang
 
 from colorama import Fore
 from config import BabbleConfig, BabbleSettingsConfig
-from utils.misc_utils import get_camera_index_by_name, list_camera_names
+from utils.misc_utils import get_camera_index_by_name, list_camera_names, is_nt
 
 from vivefacialtracker.vivetracker import ViveTracker
 from vivefacialtracker.camera_controller import FTCameraController

--- a/BabbleApp/requirements.txt
+++ b/BabbleApp/requirements.txt
@@ -1,5 +1,4 @@
 onnxruntime==1.19.2
-onnxruntime-directml==1.19.2
 opencv_python==4.10.0.84
 pillow==11.0.0
 pysimplegui==4.70.1
@@ -13,3 +12,5 @@ desktop-notifier==6.0.0
 comtypes==1.4.8
 pygrabber==0.2
 poetry
+v4l2py
+psutil


### PR DESCRIPTION
Remove "onnxruntime-directml==1.19.2" from requirements.txt
Add "v4l2py" and "psutil" to requirements.txt
Add ", is_nt" to the end of line 16 in camera.py

Fixes Babble not working under Linux