### PR TITLE
Fix: Use rotating log file w/2MB limit, changed file name 'n removed...

### DIFF
--- a/BabbleApp/logger.py
+++ b/BabbleApp/logger.py
@@ -38,6 +38,11 @@ def log_system_info(logger):
     except Exception as e:
         logger.error(f"Failed to log system information: {e}")
 
+class _RotatingFileHandler(RotatingFileHandler):
+    def doRollover(self):
+        super().doRollover()
+        # Include system info after rollover
+        log_system_info(logging.getLogger("debug_logger"))
 
 def setup_logging():
     # Log to program directory
@@ -49,7 +54,7 @@ def setup_logging():
     logger = logging.getLogger("debug_logger")
     logger.setLevel(logging.DEBUG)
 
-    file_handler = RotatingFileHandler(log_file, mode='w', maxBytes=2000000, backupCount=1, encoding='utf-8')
+    file_handler = _RotatingFileHandler(log_file, mode='w', maxBytes=2000000, backupCount=1, encoding='utf-8')
     file_handler.setLevel(logging.DEBUG)
     formatter = logging.Formatter('%(asctime)s - %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
     file_handler.setFormatter(formatter)

--- a/BabbleApp/logger.py
+++ b/BabbleApp/logger.py
@@ -4,6 +4,7 @@ import os
 import sys
 import platform
 import psutil
+from logging.handlers import RotatingFileHandler
 
 def strip_ansi_codes(text):
     """Remove ANSI color codes from a string."""
@@ -39,18 +40,16 @@ def log_system_info(logger):
 
 
 def setup_logging():
-    # Determine the user's Documents directory
-    #documents_dir = os.path.join(os.path.expanduser("~"), "Documents")
-    documents_dir = "./Logs"
-    log_dir = os.path.join(documents_dir, "ProjectBabble")
+    # Log to program directory
+    log_dir = "./Logs"
     os.makedirs(log_dir, exist_ok=True)
-    log_file = os.path.join(log_dir, "latest.log")
+    log_file = os.path.join(log_dir, "ProjectBabble.log")
 
     # Set up logging
     logger = logging.getLogger("debug_logger")
     logger.setLevel(logging.DEBUG)
 
-    file_handler = logging.FileHandler(log_file, mode='w', encoding='utf-8')
+    file_handler = RotatingFileHandler(log_file, mode='w', maxBytes=2000000, backupCount=1, encoding='utf-8')
     file_handler.setLevel(logging.DEBUG)
     formatter = logging.Formatter('%(asctime)s - %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
     file_handler.setFormatter(formatter)


### PR DESCRIPTION
Use rotating log file w/2MB limit.
Changed file name to "ProjectBabble.log" and removed "./Logs/ProjectBabble" folder. So logs go directly to "./Logs".