### PR TITLE
Revert call to get_camera_index_by_name to fix http camera access

### DIFF
--- a/BabbleApp/camera.py
+++ b/BabbleApp/camera.py
@@ -143,7 +143,7 @@ class Camera:
                         self.cv2_camera is None
                         or not self.cv2_camera.isOpened()
                         or self.camera_status == CameraState.DISCONNECTED
-                        or get_camera_index_by_name(self.config.capture_source) != self.current_capture_source
+                        or self.config.capture_source != self.current_capture_source
                     ):
                         if self.vft_camera is not None:
                             self.vft_camera.close()


### PR DESCRIPTION
Reverts a change made in f7391dc that prevents http cameras from working; get_camera_index_by_name appears to only make sense for wired cameras